### PR TITLE
Fix pre-tagged instances cleanup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: latest
+          node-version: 22
           cache: yarn
           cache-dependency-path: yarn.lock
 
@@ -110,7 +110,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: latest
+          node-version: 22
           cache: yarn
           cache-dependency-path: yarn.lock
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,9 +35,7 @@ jobs:
         run: yarn run prepare
 
       - name: Run linter
-        # lint with selene for now because luau-lsp cannot ignore errors
-        # in node_modules
-        run: yarn run lint:selene
+        run: yarn run lint
 
       - name: Verify code style
         run: yarn run style-check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: latest
+          node-version: 22
           cache: yarn
           cache-dependency-path: yarn.lock
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- fix already tagged instances cleanup ([#5](https://github.com/seaofvoices/generator-luau/pull/5))
+
 ## 0.1.1
 
 - provide the tagged config instance to the effect function when using the `useParent` and configuration options ([#3](https://github.com/seaofvoices/generator-luau/pull/3))

--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -8,6 +8,6 @@ if [ ! -f "$TYPES_FILE" ]; then
     curl https://raw.githubusercontent.com/JohnnyMorganz/luau-lsp/main/scripts/globalTypes.d.lua > $TYPES_FILE
 fi
 
-luau-lsp analyze --base-luaurc=.luaurc --settings=.luau-analyze.json \
+luau-lsp analyze --base-luaurc=.luaurc --settings=.luau-analyze.json --ignore '**/node_modules/**' --ignore 'node_modules/**' \
     --definitions=$TYPES_FILE \
     src


### PR DESCRIPTION
Existing instances that were tagged were not being cleaned up after losing their tag or being removed.

- [x] add entry to the changelog
