### PR TITLE
Fix class validation for effects not targetting parent instances

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,9 +101,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: Roblox/setup-foreman@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: CompeyDev/setup-rokit@v0.1.2
 
       - name: Enable corepack
         run: corepack enable
@@ -124,7 +122,7 @@ jobs:
         run: yarn run build
 
       - name: Upload asset
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact-name }}
           path: ${{ matrix.path }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: Roblox/setup-foreman@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: CompeyDev/setup-rokit@v0.1.2
 
       - name: Enable corepack
         run: corepack enable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- fix instance class validation bug ([#9](https://github.com/seaofvoices/generator-luau/pull/9))
+
 ## 0.1.3
 
 - fix tag configuration effect cleanup to happen only once ([#7](https://github.com/seaofvoices/generator-luau/pull/7))

--- a/foreman.toml
+++ b/foreman.toml
@@ -1,7 +1,7 @@
 [tools]
-darklua = { github = "seaofvoices/darklua", version = "=0.15.0"}
-luau-lsp = { github = "JohnnyMorganz/luau-lsp", version = "=1.38.1"}
-rojo = { github = "rojo-rbx/rojo", version = "=7.4.1"}
+darklua = { github = "seaofvoices/darklua", version = "=0.16.0"}
+luau-lsp = { github = "JohnnyMorganz/luau-lsp", version = "=1.44.1"}
+rojo = { github = "rojo-rbx/rojo", version = "=7.5.1"}
 run-in-roblox = { github = "rojo-rbx/run-in-roblox", version = "=0.3.0"}
 selene = { github = "Kampfkarren/selene", version = "=0.28.0"}
 stylua = { github = "JohnnyMorganz/StyLua", version = "=0.20.0"}

--- a/src/TagConfiguration.lua
+++ b/src/TagConfiguration.lua
@@ -152,13 +152,11 @@ function TagConfiguration:effect(tagName: string, fn: (Instance) -> Teardown): (
                     lastRefreshCleanup = nil
                     Teardown.teardown(currentCleanup)
 
-                    local target = if useParent then object.Parent else object
+                    local target = object.Parent
 
                     if target ~= nil and validateClasses and not validateClasses(target) then
-                        if useParent then
-                            lastRefreshCleanup =
-                                object:GetPropertyChangedSignal('Parent'):Connect(refresh) :: any
-                        end
+                        lastRefreshCleanup =
+                            object:GetPropertyChangedSignal('Parent'):Connect(refresh) :: any
                         return
                     end
 
@@ -176,6 +174,10 @@ function TagConfiguration:effect(tagName: string, fn: (Instance) -> Teardown): (
                     Teardown.teardown(currentCleanup)
                 end
             else
+                if validateClasses and not validateClasses(object) then
+                    return nil
+                end
+
                 return fn(object)
             end
         end
@@ -265,7 +267,10 @@ function TagConfiguration:effect(tagName: string, fn: (Instance) -> Teardown): (
                 if useParent
                     then object:GetPropertyChangedSignal('Parent'):Connect(refresh) :: any
                     else nil,
-                if target ~= nil then (fn :: any)(target, config, object) else nil
+                if target == nil
+                    then nil
+                    elseif useParent then (fn :: any)(target, config, object)
+                    else (fn :: any)(target, config)
             )
         end
 

--- a/src/__tests__/TagConfiguration.test.lua
+++ b/src/__tests__/TagConfiguration.test.lua
@@ -1,0 +1,312 @@
+local Teardown = require('@pkg/luau-teardown')
+local jestGlobals = require('@pkg/@jsdotlua/jest-globals')
+
+local TagConfiguration = require('../TagConfiguration')
+local createTaggedInstance = require('./createTaggedInstance')
+
+local expect = jestGlobals.expect
+local it = jestGlobals.it
+local describe = jestGlobals.describe
+local jest = jestGlobals.jest
+local beforeEach = jestGlobals.beforeEach
+local afterEach = jestGlobals.afterEach
+
+local cleanupFunctions = {}
+
+afterEach(function()
+    Teardown.teardown(cleanupFunctions)
+    cleanupFunctions = {}
+end)
+
+local function cleanAfterTest(...: Teardown.Teardown | Instance)
+    table.insert(cleanupFunctions, Teardown.fn(... :: any))
+end
+
+local tagCounter = 0
+local tagName = `TestTag-0`
+
+beforeEach(function()
+    tagCounter += 1
+    tagName = `TestTag-{tagCounter}`
+end)
+
+describe('new', function()
+    it('creates a new TagConfiguration instance', function()
+        local config = TagConfiguration.new()
+        expect(config).never.toBeNil()
+    end)
+end)
+
+describe('targetParent', function()
+    it('returns a new object with targetParent flag set', function()
+        local config = TagConfiguration.new()
+        local parentConfig = config:targetParent()
+
+        expect(parentConfig).never.toBe(config)
+    end)
+
+    it('applies the effect to the parent of the tagged instance', function()
+        local effectFn = jest.fn(function()
+            return function() end
+        end)
+
+        local testParent = Instance.new('Part')
+        cleanAfterTest(testParent)
+
+        local cleanup = TagConfiguration.new():targetParent():effect(tagName, effectFn)
+        cleanAfterTest(cleanup)
+
+        local taggedInstance = createTaggedInstance('Configuration', tagName, testParent)
+        cleanAfterTest(taggedInstance)
+
+        testParent.Parent = workspace
+
+        expect(effectFn).toHaveBeenCalledTimes(1)
+        expect(effectFn).toHaveBeenCalledWith(testParent, nil, taggedInstance)
+    end)
+end)
+
+describe('withDefaultConfig', function()
+    it('returns a new object with default config', function()
+        local config = TagConfiguration.new()
+
+        local configWithDefaults = config:withDefaultConfig({ value = '' }, { value = 'string' })
+
+        expect(configWithDefaults).never.toBe(config)
+    end)
+
+    it('merges the default config with the tagged instance attributes', function()
+        local effectFn = jest.fn(function()
+            return function() end
+        end)
+
+        local cleanup = TagConfiguration.new()
+            :withDefaultConfig({ color = 'blue', size = 5 })
+            :effect(tagName, effectFn)
+        cleanAfterTest(cleanup)
+
+        local taggedInstance = createTaggedInstance('Folder', tagName, nil, {
+            color = 'red',
+        })
+        cleanAfterTest(taggedInstance)
+
+        expect(effectFn).toHaveBeenCalledTimes(1)
+        expect(effectFn).toHaveBeenCalledWith(taggedInstance, { color = 'red', size = 5 })
+    end)
+
+    if _G.DEV then
+        it('does not run the effect function if the config schema is not met', function()
+            local effectFn = jest.fn(function()
+                return function() end
+            end)
+
+            local cleanup = TagConfiguration.new()
+                :withDefaultConfig({ color = 'blue' }, { color = 'string' })
+                :effect(tagName, effectFn)
+            cleanAfterTest(cleanup)
+
+            local taggedInstance = createTaggedInstance('Folder', tagName, nil, {
+                color = false,
+            })
+            cleanAfterTest(taggedInstance)
+
+            expect(effectFn).never.toHaveBeenCalled()
+        end)
+    end
+
+    it('re-runs the effect when an attribute changes', function()
+        local effectFn = jest.fn(function()
+            return function() end
+        end)
+
+        local cleanup =
+            TagConfiguration.new():withDefaultConfig({ color = 'blue' }):effect(tagName, effectFn)
+        cleanAfterTest(cleanup)
+
+        local taggedInstance = createTaggedInstance('Folder', tagName, nil, {
+            color = 'red',
+        })
+        cleanAfterTest(taggedInstance)
+
+        expect(effectFn).toHaveBeenCalledTimes(1)
+        expect(effectFn).toHaveBeenCalledWith(taggedInstance, { color = 'red' })
+
+        taggedInstance:SetAttribute('color', 'green')
+
+        expect(effectFn).toHaveBeenCalledTimes(2)
+        expect(effectFn).toHaveBeenCalledWith(taggedInstance, { color = 'green' })
+    end)
+end)
+
+describe('withValidClass', function()
+    it('returns a new object with valid classes', function()
+        local config = TagConfiguration.new()
+        local configWithClasses = config:withValidClass('Folder', 'Part')
+
+        expect(configWithClasses).never.toBe(config)
+    end)
+
+    it('applies the effect to a valid class', function()
+        local effectFn = jest.fn(function()
+            return function() end
+        end)
+
+        local cleanup = TagConfiguration.new():withValidClass('Part'):effect(tagName, effectFn)
+        cleanAfterTest(cleanup)
+
+        local validInstance = createTaggedInstance('Part', tagName)
+        cleanAfterTest(validInstance)
+
+        expect(effectFn).toHaveBeenCalledWith(validInstance)
+    end)
+
+    it('applies the effect to a derived class', function()
+        local effectFn = jest.fn(function()
+            return function() end
+        end)
+
+        local cleanup = TagConfiguration.new():withValidClass('BasePart'):effect(tagName, effectFn)
+        cleanAfterTest(cleanup)
+
+        local validInstance = createTaggedInstance('Part', tagName)
+        cleanAfterTest(validInstance)
+
+        expect(effectFn).toHaveBeenCalledWith(validInstance)
+    end)
+
+    it('does not apply the effect to an invalid class', function()
+        local effectFn = jest.fn(function()
+            return function() end
+        end)
+
+        local cleanup = TagConfiguration.new():withValidClass('Part'):effect(tagName, effectFn)
+        cleanAfterTest(cleanup)
+
+        local invalidInstance = createTaggedInstance('Folder', tagName)
+        cleanAfterTest(invalidInstance)
+
+        expect(effectFn).never.toHaveBeenCalled()
+    end)
+
+    describe('with targetParent', function()
+        it('applies the effect to a valid class', function()
+            local effectFn = jest.fn(function()
+                return function() end
+            end)
+
+            local cleanup = TagConfiguration.new()
+                :targetParent()
+                :withValidClass('Part')
+                :effect(tagName, effectFn)
+            cleanAfterTest(cleanup)
+
+            local target = Instance.new('Part')
+            target.Parent = workspace
+
+            local validInstance = createTaggedInstance('Configuration', tagName, target)
+            cleanAfterTest(validInstance)
+
+            expect(effectFn).toHaveBeenCalledWith(target, nil, validInstance)
+        end)
+
+        it('applies the effect to a derived class', function()
+            local effectFn = jest.fn(function()
+                return function() end
+            end)
+
+            local cleanup = TagConfiguration.new()
+                :targetParent()
+                :withValidClass('BasePart')
+                :effect(tagName, effectFn)
+            cleanAfterTest(cleanup)
+
+            local target = Instance.new('Part')
+            target.Parent = workspace
+
+            local validInstance = createTaggedInstance('Configuration', tagName, target)
+            cleanAfterTest(validInstance)
+
+            expect(effectFn).toHaveBeenCalledWith(target, nil, validInstance)
+        end)
+
+        it('does not apply the effect to an invalid class', function()
+            local effectFn = jest.fn(function()
+                return function() end
+            end)
+
+            local cleanup = TagConfiguration.new()
+                :targetParent()
+                :withValidClass('Part')
+                :effect(tagName, effectFn)
+            cleanAfterTest(cleanup)
+
+            local target = Instance.new('Folder')
+            target.Parent = workspace
+
+            local invalidInstance = createTaggedInstance('Configuration', tagName, target)
+            cleanAfterTest(invalidInstance)
+
+            expect(effectFn).never.toHaveBeenCalled()
+        end)
+    end)
+end)
+
+describe('ignoreDescendantOf', function()
+    it('returns a new object with ignore descendants', function()
+        local config = TagConfiguration.new()
+        local configWithIgnore = config:ignoreDescendantOf(workspace)
+
+        expect(configWithIgnore).never.toBe(config)
+    end)
+
+    it('does not apply effect to instances that are descendants of ignored ancestors', function()
+        local ignoreRoot = Instance.new('Folder')
+        cleanAfterTest(ignoreRoot)
+
+        local effectFn = jest.fn(function()
+            return function() end
+        end)
+
+        local config = TagConfiguration.new():ignoreDescendantOf(ignoreRoot)
+        local cleanup = config:effect(tagName, effectFn)
+        cleanAfterTest(cleanup)
+
+        local normalInstance = createTaggedInstance('Folder', tagName)
+        local ignoredInstance = createTaggedInstance('Folder', tagName, ignoreRoot)
+        cleanAfterTest(normalInstance, ignoredInstance)
+
+        expect(effectFn).toHaveBeenCalledWith(normalInstance)
+        expect(effectFn).never.toHaveBeenCalledWith(ignoredInstance)
+    end)
+end)
+
+describe('includeDescendantOf', function()
+    it('returns a new object with include descendants', function()
+        local config = TagConfiguration.new()
+
+        local configWithInclude = config:includeDescendantOf(workspace)
+
+        expect(configWithInclude).never.toBe(config)
+    end)
+
+    it('applies effect to instances that are descendants of included ancestors', function()
+        local includeRoot = Instance.new('Folder')
+        includeRoot.Parent = workspace
+        cleanAfterTest(includeRoot)
+
+        local effectFn = jest.fn(function()
+            return function() end
+        end)
+
+        local config = TagConfiguration.new():includeDescendantOf(includeRoot)
+        local cleanup = config:effect(tagName, effectFn)
+        cleanAfterTest(cleanup)
+
+        local includedInstance = createTaggedInstance('Folder', tagName, includeRoot)
+        local unrelatedInstance = createTaggedInstance('Folder', tagName)
+        cleanAfterTest(includedInstance, unrelatedInstance)
+
+        expect(effectFn).toHaveBeenCalledWith(includedInstance)
+        expect(effectFn).never.toHaveBeenCalledWith(unrelatedInstance)
+    end)
+end)

--- a/src/__tests__/createTagEffect.test.lua
+++ b/src/__tests__/createTagEffect.test.lua
@@ -1,0 +1,167 @@
+local Teardown = require('@pkg/luau-teardown')
+local jestGlobals = require('@pkg/@jsdotlua/jest-globals')
+
+local createTagEffect = require('../createTagEffect')
+local createTaggedInstance = require('./createTaggedInstance')
+
+local expect = jestGlobals.expect
+local it = jestGlobals.it
+local jest = jestGlobals.jest
+local beforeEach = jestGlobals.beforeEach
+local afterEach = jestGlobals.afterEach
+
+local cleanupFunctions = {}
+
+local tagCounter = 0
+local tagName = `TestTag-0`
+
+beforeEach(function()
+    tagCounter += 1
+    tagName = `TestTag-{tagCounter}`
+end)
+
+afterEach(function()
+    Teardown.teardown(cleanupFunctions)
+    cleanupFunctions = {}
+end)
+
+local function cleanAfterTest(...: Teardown.Teardown | Instance)
+    table.insert(cleanupFunctions, Teardown.fn(... :: any))
+end
+
+it('returns a cleanup function', function()
+    local cleanup = createTagEffect(tagName, function()
+        return nil
+    end)
+    expect(typeof(cleanup)).toBe('function')
+    cleanup()
+end)
+
+it('runs the effect function for a newly created tagged instance', function()
+    local effectFn = jest.fn(function()
+        return function() end
+    end)
+
+    local cleanup = createTagEffect(tagName, effectFn)
+    cleanAfterTest(cleanup)
+
+    local instance = createTaggedInstance('Folder', tagName, workspace)
+    cleanAfterTest(instance)
+
+    expect(effectFn).toHaveBeenCalledTimes(1)
+    expect(effectFn).toHaveBeenCalledWith(instance)
+end)
+
+it('runs the effect function for a newly created instance when the tag is added', function()
+    local effectFn = jest.fn(function()
+        return function() end
+    end)
+
+    local cleanup = createTagEffect(tagName, effectFn)
+    cleanAfterTest(cleanup)
+
+    local instance = Instance.new('Folder')
+    instance.Parent = workspace
+    cleanAfterTest(instance)
+
+    expect(effectFn).never.toHaveBeenCalled()
+
+    instance:AddTag(tagName)
+
+    expect(effectFn).toHaveBeenCalledTimes(1)
+    expect(effectFn).toHaveBeenCalledWith(instance)
+end)
+
+it('runs the effect function for an already tagged instance', function()
+    local instance = createTaggedInstance('Folder', tagName)
+    cleanAfterTest(instance)
+
+    local effectFn = jest.fn(function()
+        return function() end
+    end)
+
+    local cleanup = createTagEffect(tagName, effectFn)
+    cleanAfterTest(cleanup)
+
+    expect(effectFn).toHaveBeenCalledWith(instance)
+end)
+
+it('cleans up effects when a tag is removed', function()
+    local cleanupFn = jest.fn()
+
+    local effectFn = jest.fn(function()
+        return function()
+            cleanupFn()
+        end
+    end)
+
+    local cleanup = createTagEffect(tagName, effectFn)
+    cleanAfterTest(cleanup)
+
+    local instance = createTaggedInstance('Folder', tagName, workspace)
+    cleanAfterTest(instance)
+
+    expect(effectFn).toHaveBeenCalledWith(instance)
+    expect(cleanupFn).never.toHaveBeenCalled()
+
+    instance:RemoveTag(tagName)
+
+    expect(cleanupFn).toHaveBeenCalled()
+end)
+
+it('cleans up effects when the instance is un-parented', function()
+    local cleanupFn = jest.fn()
+
+    local effectFn = jest.fn(function()
+        return function()
+            cleanupFn()
+        end
+    end)
+
+    local cleanup = createTagEffect(tagName, effectFn)
+    cleanAfterTest(cleanup)
+
+    local instance = createTaggedInstance('Folder', tagName, workspace)
+    cleanAfterTest(instance)
+
+    expect(effectFn).toHaveBeenCalledWith(instance)
+    expect(cleanupFn).never.toHaveBeenCalled()
+
+    instance.Parent = nil
+
+    expect(cleanupFn).toHaveBeenCalled()
+end)
+
+it('cleans up all effects when the main cleanup function is called', function()
+    local cleanupFn1 = jest.fn()
+    local cleanupFn2 = jest.fn()
+
+    local callCount = 0
+    local effectFn = jest.fn(function()
+        callCount += 1
+        if callCount == 1 then
+            return function()
+                cleanupFn1()
+            end
+        else
+            return function()
+                cleanupFn2()
+            end
+        end
+    end)
+
+    local cleanup = createTagEffect(tagName, effectFn)
+
+    local instance1 = createTaggedInstance('Folder', tagName, workspace)
+    local instance2 = createTaggedInstance('Folder', tagName, workspace)
+    cleanAfterTest(instance1, instance2)
+
+    expect(effectFn).toHaveBeenCalledTimes(2)
+    expect(cleanupFn1).never.toHaveBeenCalled()
+    expect(cleanupFn2).never.toHaveBeenCalled()
+
+    cleanup()
+
+    expect(cleanupFn1).toHaveBeenCalled()
+    expect(cleanupFn2).toHaveBeenCalled()
+end)

--- a/src/__tests__/createTaggedInstance.lua
+++ b/src/__tests__/createTaggedInstance.lua
@@ -1,0 +1,22 @@
+local function createTaggedInstance(
+    className: string,
+    tagName: string,
+    parent: Instance?,
+    attributes: { [string]: any }?
+)
+    local instance = Instance.new(className)
+
+    if attributes then
+        for name, value in pairs(attributes) do
+            instance:SetAttribute(name, value)
+        end
+    end
+
+    instance:AddTag(tagName)
+
+    instance.Parent = parent or game:GetService('Workspace')
+
+    return instance
+end
+
+return createTaggedInstance


### PR DESCRIPTION
Fixed a specific case where instance classes were not verified. This happened for configured tags that were not calling `useParent()` and without using the attribute based configuration.

- [x] add entry to the changelog
